### PR TITLE
Site audit pass 3: 404 navigation, mobile layout glitches

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,20 +1,29 @@
 import Link from "next/link";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
 
 export default function NotFound() {
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
-			<h1 className="mb-2 text-6xl font-bold tracking-tight text-foreground">
-				404
-			</h1>
-			<p className="mb-8 text-lg text-muted">
-				The page you are looking for does not exist.
-			</p>
-			<Link
-				href="/"
-				className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl border border-border bg-accent px-6 py-3 font-medium text-white transition-all hover:bg-accent-dark focus-visible:ring-2 focus-visible:ring-border"
+		<>
+			<Navbar />
+			<main
+				id="main-content"
+				className="flex min-h-screen flex-col items-center justify-center px-4 pt-24 pb-12 text-center"
 			>
-				Go Home
-			</Link>
-		</main>
+				<h1 className="mb-2 text-6xl font-bold tracking-tight text-foreground">
+					404
+				</h1>
+				<p className="mb-8 text-lg text-muted">
+					The page you are looking for does not exist.
+				</p>
+				<Link
+					href="/"
+					className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl border border-border bg-accent px-6 py-3 font-medium text-white transition-all hover:bg-accent-dark focus-visible:ring-2 focus-visible:ring-border"
+				>
+					Go Home
+				</Link>
+			</main>
+			<Footer />
+		</>
 	);
 }

--- a/src/components/bento/ContactCard.tsx
+++ b/src/components/bento/ContactCard.tsx
@@ -77,14 +77,14 @@ export function ContactCard() {
 					Languages
 				</h2>
 				<div className="min-w-0 overflow-hidden pr-2">
-					<div className="grid grid-cols-1 gap-y-3 sm:grid-cols-[auto_1fr_minmax(8rem,12rem)] sm:gap-x-4">
+					<div className="flex flex-col gap-y-3 sm:grid sm:grid-cols-[auto_1fr_minmax(8rem,12rem)] sm:gap-x-4">
 					{profile.languages.map((lang) => (
 						<div
 							key={lang.name}
-							className="col-span-3 grid grid-cols-subgrid items-center gap-x-4 rounded-lg border border-border bg-surface px-3 py-2"
+							className="flex items-center gap-x-4 rounded-lg border border-border bg-surface px-3 py-2 sm:col-span-3 sm:grid sm:grid-cols-subgrid"
 						>
-							<span className="text-lg">{lang.flag}</span>
-							<span className="text-foreground">{lang.name}</span>
+							<span className="inline-block min-w-[1.5em] text-lg leading-none">{lang.flag}</span>
+							<span className="flex-1 text-foreground">{lang.name}</span>
 							<span
 								className={`text-right text-sm ${
 									lang.native ? "text-accent" : "text-muted"

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -38,7 +38,7 @@ export function Navbar() {
 			<div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
 				<Link
 					href="/"
-					className="text-lg font-bold tracking-tight text-foreground transition-colors hover:text-accent"
+					className="whitespace-nowrap text-lg font-bold tracking-tight text-foreground transition-colors hover:text-accent"
 					aria-label="Go to homepage"
 				>
 					AL Tech Solutions


### PR DESCRIPTION
## Summary
Third audit pass — tested the interface across 320px, 375px, 768px, 1280px, and 1920px viewports plus all subpages, and found three layout/UX bugs that the first two passes didn't surface.

### Fixes

- **404 page had no Navbar or Footer.** Hitting any non-existent path (e.g. `/foo`) gave users a bare 404 with only a \"Go Home\" link — no menu, no footer, no contact info, nothing. Added `<Navbar />` and `<Footer />` so navigation stays consistent with the rest of the site.
- **Brand \"AL Tech Solutions\" wrapped to 2 lines at 320px**, pushing the navbar height from 28px to 56px and visually overlapping the page below. Added `whitespace-nowrap` so the brand always stays on one line.
- **Language flag emojis had 0 layout width on mobile.** The `col-span-3 grid grid-cols-subgrid` trick in [ContactCard](src/components/bento/ContactCard.tsx) collapsed when the parent grid was a single column — measured the flag span at width=0 in `getBoundingClientRect()`, which let the emoji glyph visually overflow into the language name (\"🇬🇧English\" with no gap). Switched the language list to flex on mobile, kept subgrid for `sm:` and up, and gave the flag span an explicit `min-w-[1.5em]`.

### Other findings I checked and confirmed working
- Heading hierarchy: 1 H1, then H2/H3 properly nested ✓
- All 15 images load (no 404s) ✓
- Cookie banner: opens, accept/reject works, GA loads only after accept ✓
- Theme toggle: switches html class + persists ✓
- Lite mode toggle: persists + changes nav background ✓
- Mobile menu: opens with About/Experience/Resume/Contact/Privacy ✓
- ExpandableDescription \"Show more / Show less\" toggle works ✓
- Tables in privacy/cookie pages have proper `overflow-x-auto` wrappers ✓
- Resume / Diploma / Diploma Supplement viewer pages all generate ✓

### Known issue (not addressed)
- **Mobile menu has marginal contrast when expanded** — `bg-surface backdrop-blur-[20px]` lets the hero image bleed through, making links a bit hard to read. Left as-is because tightening it would change the overall design system; flagging for future work.

## Test plan
- [x] `npm run lint` → 0 errors (6 pre-existing `<img>` warnings)
- [x] `npm run build` → all 9 routes generate
- [x] Live verification at 320px, 375px, 768px, 1280px, 1920px
- [x] Live verification: 404 page now has nav + footer (`navLinkCount: 6`)
- [x] Live verification: brand stays 28px tall at 320px (was 56px)
- [x] Live verification: flag width is now 27px with 16px gap to name (was 0px, no gap)
- [ ] Reviewer: hit a real 404 in production after deploy and confirm nav renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)