### PR TITLE
ci: add PR validation with lint, typecheck, build, spell, links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches-ignore: [main, gh-pages]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-typecheck:
+    name: Lint, type-check, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: TypeScript type-check
+        run: npm run typecheck
+
+      - name: Build (next build)
+        run: npm run build
+
+  spell-check:
+    name: Spell check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: cspell
+        run: npm run spell
+
+  link-check:
+    name: Link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config ./lychee.toml
+            README.md
+            src/
+            public/sitemap.xml
+            public/manifest.json
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,8 +18,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version-file: .nvmrc
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -24,7 +28,7 @@ jobs:
         run: npm run lint
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Build
         run: npm run build

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,53 @@
+{
+	"version": "0.2",
+	"language": "en,en-GB",
+	"useGitignore": true,
+	"ignorePaths": [
+		".next/**",
+		"out/**",
+		"node_modules/**",
+		"package-lock.json",
+		"public/pdf/**",
+		"src/lib/iconPaths.ts",
+		"src/data/skillIcons.ts"
+	],
+	"words": [
+		"Aiogram",
+		"alytvynenko",
+		"Andrii",
+		"Corosync",
+		"Częstochowa",
+		"darkreader",
+		"epam",
+		"EPAM",
+		"fecton",
+		"geniusee",
+		"Geniusee",
+		"glassmorphism",
+		"HLASM",
+		"khai",
+		"Laravel",
+		"LKHDQT",
+		"Lucidchart",
+		"luxoft",
+		"Luxoft",
+		"lvmlockd",
+		"Lytvynenko",
+		"MBUX",
+		"Moniuszki",
+		"MWAA",
+		"noopener",
+		"noreferrer",
+		"REGON",
+		"Stanisława",
+		"Tkinter",
+		"UODO",
+		"Voivodeship"
+	],
+	"flagWords": [],
+	"ignoreRegExpList": [
+		"https?://[^\\s)\"']+",
+		"\\bd=\"[^\"]+\"",
+		"viewBox=\"[^\"]+\""
+	]
+}

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,7 +1,10 @@
 # Lychee link-checker config — used by .github/workflows/ci.yml
 
-# Treat 999 (LinkedIn anti-bot) and 403 (Mercedes-Benz/EPAM anti-bot) as success.
-accept = ["200..=299", "403", "999"]
+# Treat anti-bot status codes as success:
+#   403 — Mercedes-Benz, EPAM, etc. block non-browser User-Agents
+#   429 — Instagram rate-limits CI runners
+#   999 — LinkedIn returns this for any non-browser request
+accept = ["200..=299", "403", "429", "999"]
 
 max_concurrency = 4
 no_progress = true

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,33 @@
+# Lychee link-checker config — used by .github/workflows/ci.yml
+
+# Treat 999 (LinkedIn anti-bot) and 403 (Mercedes-Benz/EPAM anti-bot) as success.
+accept = ["200..=299", "403", "999"]
+
+max_concurrency = 4
+no_progress = true
+
+# Scan source files, not just markdown.
+extensions = ["md", "ts", "tsx", "xml", "json"]
+
+# Don't follow redirects through more than 5 hops.
+max_redirects = 5
+
+# Skip these — either site-internal patterns or known-good but bot-blocked.
+# LinkedIn returns 404/405/999 to non-browser clients, so exclude entirely.
+# Telegram and WhatsApp short links don't respond well to HEAD/GET probes.
+exclude = [
+    "^https?://localhost",
+    "^https?://127\\.0\\.0\\.1",
+    "^https://(www\\.)?linkedin\\.com/",
+    "^https://wa\\.me/",
+    "^https://t\\.me/",
+    "^https://api\\.whatsapp\\.com/",
+]
+
+# What to scan: source files + content files. Skip build output.
+exclude_path = [
+    "node_modules",
+    ".next",
+    "out",
+    "public/pdf",
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@types/react": "^19.0.0",
 				"@types/react-dom": "^19.0.0",
 				"autoprefixer": "^10.4.24",
+				"cspell": "^10.0.0",
 				"eslint": "^9",
 				"eslint-config-next": "^16.1.6",
 				"postcss": "^8",
@@ -313,6 +314,635 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@cspell/cspell-bundled-dicts": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.0.tgz",
+			"integrity": "sha512-ci410HEkng2582oOjlRHQtlGXwh+rUC/mVcN9dObLHpKhvPgzn2S6vT56pARstxxZpcCUG/oLhn3dCqdJlVzmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/dict-ada": "^4.1.1",
+				"@cspell/dict-al": "^1.1.1",
+				"@cspell/dict-aws": "^4.0.17",
+				"@cspell/dict-bash": "^4.2.2",
+				"@cspell/dict-companies": "^3.2.11",
+				"@cspell/dict-cpp": "^7.0.2",
+				"@cspell/dict-cryptocurrencies": "^5.0.5",
+				"@cspell/dict-csharp": "^4.0.8",
+				"@cspell/dict-css": "^4.1.1",
+				"@cspell/dict-dart": "^2.3.2",
+				"@cspell/dict-data-science": "^2.0.13",
+				"@cspell/dict-django": "^4.1.6",
+				"@cspell/dict-docker": "^1.1.17",
+				"@cspell/dict-dotnet": "^5.0.13",
+				"@cspell/dict-elixir": "^4.0.8",
+				"@cspell/dict-en_us": "^4.4.33",
+				"@cspell/dict-en-common-misspellings": "^2.1.12",
+				"@cspell/dict-en-gb-mit": "^3.1.22",
+				"@cspell/dict-filetypes": "^3.0.18",
+				"@cspell/dict-flutter": "^1.1.1",
+				"@cspell/dict-fonts": "^4.0.6",
+				"@cspell/dict-fsharp": "^1.1.1",
+				"@cspell/dict-fullstack": "^3.2.9",
+				"@cspell/dict-gaming-terms": "^1.1.2",
+				"@cspell/dict-git": "^3.1.0",
+				"@cspell/dict-golang": "^6.0.26",
+				"@cspell/dict-google": "^1.0.9",
+				"@cspell/dict-haskell": "^4.0.6",
+				"@cspell/dict-html": "^4.0.15",
+				"@cspell/dict-html-symbol-entities": "^4.0.5",
+				"@cspell/dict-java": "^5.0.12",
+				"@cspell/dict-julia": "^1.1.1",
+				"@cspell/dict-k8s": "^1.0.12",
+				"@cspell/dict-kotlin": "^1.1.1",
+				"@cspell/dict-latex": "^5.1.0",
+				"@cspell/dict-lorem-ipsum": "^4.0.5",
+				"@cspell/dict-lua": "^4.0.8",
+				"@cspell/dict-makefile": "^1.0.5",
+				"@cspell/dict-markdown": "^2.0.16",
+				"@cspell/dict-monkeyc": "^1.0.12",
+				"@cspell/dict-node": "^5.0.9",
+				"@cspell/dict-npm": "^5.2.38",
+				"@cspell/dict-php": "^4.1.1",
+				"@cspell/dict-powershell": "^5.0.15",
+				"@cspell/dict-public-licenses": "^2.0.16",
+				"@cspell/dict-python": "^4.2.26",
+				"@cspell/dict-r": "^2.1.1",
+				"@cspell/dict-ruby": "^5.1.1",
+				"@cspell/dict-rust": "^4.1.2",
+				"@cspell/dict-scala": "^5.0.9",
+				"@cspell/dict-shell": "^1.1.2",
+				"@cspell/dict-software-terms": "^5.2.2",
+				"@cspell/dict-sql": "^2.2.1",
+				"@cspell/dict-svelte": "^1.0.7",
+				"@cspell/dict-swift": "^2.0.6",
+				"@cspell/dict-terraform": "^1.1.3",
+				"@cspell/dict-typescript": "^3.2.3",
+				"@cspell/dict-vue": "^3.0.5",
+				"@cspell/dict-zig": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-json-reporter": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.0.tgz",
+			"integrity": "sha512-hq5dui2ngYMZKbBauX7K1tkqlu81sX/uaCO49ZJLPjeZsE1auZLtHehDLfAr/ZXoj/dLYeQMSKiaJyE+qLVPHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-types": "10.0.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-performance-monitor": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.0.tgz",
+			"integrity": "sha512-2vMh2pLt2dg/ArYvWjMP4v9HCm0pRhONsEJyc8oHdZyOYvX7trixX894I0M39+VBf3yWtPCEgYRh1UDXNIZRig==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-pipe": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.0.tgz",
+			"integrity": "sha512-qcgHhQvtEX8LSwIVsWrdUgiGim52lN3jT+ghlkdp72v+nBcGKsS2frEKTmbGLug+xcqppkzs6Q6VmsFp1MGtfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-resolver": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.0.tgz",
+			"integrity": "sha512-8H+IUDB7SmrpcRugQ5f55qG81ZShk6nQRk+natLz41TEY98D8/LCmjHEkh/vhDPph9pVJmNUp7JcM2E1UHEa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"global-directory": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-service-bus": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.0.tgz",
+			"integrity": "sha512-V7eigqg/TOoKwNK4Q18wr9KGxA8U5SFcoWVS8RyAxv4mQ+yNKHhvHEbRBifjPbQDer66afOrclb2UbqkIy2SOw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-types": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.0.tgz",
+			"integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/cspell-worker": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.0.tgz",
+			"integrity": "sha512-V5bjMldNksilnja3fu8muQmkW5/guyua1yNVOhoE2r7othSvjuDlGMl8g2bQSrWjp+UXu0dP/BEZ6JC/IfNwTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cspell-lib": "10.0.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/dict-ada": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
+			"integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-al": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
+			"integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-aws": {
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.17.tgz",
+			"integrity": "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-bash": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.2.2.tgz",
+			"integrity": "sha512-kyWbwtX3TsCf5l49gGQIZkRLaB/P8g73GDRm41Zu8Mv51kjl2H7Au0TsEvHv7jzcsRLS6aUYaZv6Zsvk1fOz+Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/dict-shell": "1.1.2"
+			}
+		},
+		"node_modules/@cspell/dict-companies": {
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.11.tgz",
+			"integrity": "sha512-0cmafbcz2pTHXLd59eLR1gvDvN6aWAOM0+cIL4LLF9GX9yB2iKDNrKsvs4tJRqutoaTdwNFBbV0FYv+6iCtebQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-cpp": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-7.0.2.tgz",
+			"integrity": "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-cryptocurrencies": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.5.tgz",
+			"integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-csharp": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.8.tgz",
+			"integrity": "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-css": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
+			"integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-dart": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.2.tgz",
+			"integrity": "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-data-science": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.13.tgz",
+			"integrity": "sha512-l1HMEhBJkPmw4I2YGVu2eBSKM89K9pVF+N6qIr5Uo5H3O979jVodtuwP8I7LyPrJnC6nz28oxeGRCLh9xC5CVA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-django": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.6.tgz",
+			"integrity": "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-docker": {
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.17.tgz",
+			"integrity": "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-dotnet": {
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.13.tgz",
+			"integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-elixir": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
+			"integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-en_us": {
+			"version": "4.4.33",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.33.tgz",
+			"integrity": "sha512-zWftVqfUStDA37wO1ZNDN1qMJOfcxELa8ucHW8W8wBAZY3TK5Nb6deLogCK/IJi/Qljf30dwwuqqv84Qqle9Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-en-common-misspellings": {
+			"version": "2.1.12",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.12.tgz",
+			"integrity": "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw==",
+			"dev": true,
+			"license": "CC BY-SA 4.0"
+		},
+		"node_modules/@cspell/dict-en-gb-mit": {
+			"version": "3.1.22",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.22.tgz",
+			"integrity": "sha512-xE5Vg6gGdMkZ1Ep6z9SJMMioGkkT1GbxS5Mm0U3Ey1/H68P0G7cJcyiVr1CARxFbLqKE4QUpoV1o6jz1Z5Yl9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-filetypes": {
+			"version": "3.0.18",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.18.tgz",
+			"integrity": "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-flutter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
+			"integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-fonts": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.6.tgz",
+			"integrity": "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-fsharp": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
+			"integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-fullstack": {
+			"version": "3.2.9",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.9.tgz",
+			"integrity": "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-gaming-terms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.2.tgz",
+			"integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-git": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.1.0.tgz",
+			"integrity": "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-golang": {
+			"version": "6.0.26",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.26.tgz",
+			"integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-google": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
+			"integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-haskell": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
+			"integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-html": {
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
+			"integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-html-symbol-entities": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
+			"integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-java": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
+			"integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-julia": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
+			"integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-k8s": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.12.tgz",
+			"integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-kotlin": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
+			"integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-latex": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-5.1.0.tgz",
+			"integrity": "sha512-qxT4guhysyBt0gzoliXYEBYinkAdEtR2M7goRaUH0a7ltCsoqqAeEV8aXYRIdZGcV77gYSobvu3jJL038tlPAw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-lorem-ipsum": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.5.tgz",
+			"integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-lua": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
+			"integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-makefile": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
+			"integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-markdown": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.16.tgz",
+			"integrity": "sha512-976RRqKv6cwhrxdFCQP2DdnBVB86BF57oQtPHy4Zbf4jF/i2Oy29MCrxirnOBalS1W6KQeto7NdfDXRAwkK4PQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@cspell/dict-css": "^4.1.1",
+				"@cspell/dict-html": "^4.0.15",
+				"@cspell/dict-html-symbol-entities": "^4.0.5",
+				"@cspell/dict-typescript": "^3.2.3"
+			}
+		},
+		"node_modules/@cspell/dict-monkeyc": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.12.tgz",
+			"integrity": "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-node": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.9.tgz",
+			"integrity": "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-npm": {
+			"version": "5.2.38",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.38.tgz",
+			"integrity": "sha512-21ucGRPYYhr91C2cDBoMPTrcIOStQv33xOqJB0JLoC5LAs2Sfj9EoPGhGb+gIFVHz6Ia7JQWE2SJsOVFJD1wmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-php": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.1.tgz",
+			"integrity": "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-powershell": {
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
+			"integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-public-licenses": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.16.tgz",
+			"integrity": "sha512-EQRrPvEOmwhwWezV+W7LjXbIBjiy6y/shrET6Qcpnk3XANTzfvWflf9PnJ5kId/oKWvihFy0za0AV1JHd03pSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-python": {
+			"version": "4.2.26",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.26.tgz",
+			"integrity": "sha512-hbjN6BjlSgZOG2dA2DtvYNGBM5Aq0i0dHaZjMOI9K/9vRicVvKbcCiBSSrR3b+jwjhQL5ff7HwG5xFaaci0GQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/dict-data-science": "^2.0.13"
+			}
+		},
+		"node_modules/@cspell/dict-r": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
+			"integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-ruby": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.1.tgz",
+			"integrity": "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-rust": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.1.2.tgz",
+			"integrity": "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-scala": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.9.tgz",
+			"integrity": "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-shell": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.1.2.tgz",
+			"integrity": "sha512-WqOUvnwcHK1X61wAfwyXq04cn7KYyskg90j4lLg3sGGKMW9Sq13hs91pqrjC44Q+lQLgCobrTkMDw9Wyl9nRFA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-software-terms": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.2.tgz",
+			"integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-sql": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
+			"integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-svelte": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
+			"integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-swift": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
+			"integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-terraform": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.3.tgz",
+			"integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-typescript": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
+			"integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-vue": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
+			"integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dict-zig": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-zig/-/dict-zig-1.0.0.tgz",
+			"integrity": "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@cspell/dynamic-import": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.0.tgz",
+			"integrity": "sha512-fMqu/5Ma1Q5ZCR/Par+Q4pvaTKmx5pKZzQmkwld2hNounVdk2OaIPM9MzpNn6I1mLk5J+wTnIZmfcWNAzNP9aQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/url": "10.0.0",
+				"import-meta-resolve": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/filetypes": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.0.tgz",
+			"integrity": "sha512-UP57j9yrDtlCHpFxc/eGho1m8DP5olfu9KRWwd5fiqL9nMSE2rUJtPzQyvqmDwO5bVZt3B+fTVdo4gxuiqw25A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/rpc": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.0.tgz",
+			"integrity": "sha512-QrpOZMwz2pAjvl6Hky2PauYoMpLCASn3osjn7uKUbgFV70sahyj6tmx4rRgRX7vHu2WQLZev+YsuO4EujiBDOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/strong-weak-map": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.0.tgz",
+			"integrity": "sha512-JRsato0s2IjYdsng+AGL6oAqgZVQgih5aWKdmxs21H6EdhMaoFDmRE5kXm/RT5a6OMdtnzQM9DqeToqBChWIOQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/@cspell/url": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.0.tgz",
+			"integrity": "sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1938,6 +2568,19 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2038,6 +2681,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/array-timsort": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+			"integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/array.prototype.findlast": {
 			"version": "1.2.5",
@@ -2576,6 +3226,35 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/chalk-template": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+			"integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk-template?sponsor=1"
+			}
+		},
+		"node_modules/chalk-template/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2663,6 +3342,20 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/comment-json": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+			"integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-timsort": "^1.0.3",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2697,6 +3390,249 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/cspell": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.0.tgz",
+			"integrity": "sha512-R25gsSR1SLlcGyw48fwJwp0PjXrVdl7RDO/Dm5+s4DvC1uQSlyiUxsr/8ZtbyC/MPeUJFQN9B4luqLlSm0WelQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-json-reporter": "10.0.0",
+				"@cspell/cspell-performance-monitor": "10.0.0",
+				"@cspell/cspell-pipe": "10.0.0",
+				"@cspell/cspell-types": "10.0.0",
+				"@cspell/cspell-worker": "10.0.0",
+				"@cspell/dynamic-import": "10.0.0",
+				"@cspell/url": "10.0.0",
+				"ansi-regex": "^6.2.2",
+				"chalk": "^5.6.2",
+				"chalk-template": "^1.1.2",
+				"commander": "^14.0.3",
+				"cspell-config-lib": "10.0.0",
+				"cspell-dictionary": "10.0.0",
+				"cspell-gitignore": "10.0.0",
+				"cspell-glob": "10.0.0",
+				"cspell-io": "10.0.0",
+				"cspell-lib": "10.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"flatted": "^3.4.2",
+				"semver": "^7.7.4",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"cspell": "bin.mjs",
+				"cspell-esm": "bin.mjs"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			},
+			"funding": {
+				"url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+			}
+		},
+		"node_modules/cspell-config-lib": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.0.tgz",
+			"integrity": "sha512-HWK7SRnJ3N/kOThw/uzmXmQYCzBxu58Jkq2hHyte1voDl118BeNFoaNRWMpYdHbBi3kCj8gaZu8wGtm+Zmdhxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-types": "10.0.0",
+				"comment-json": "^4.6.2",
+				"smol-toml": "^1.6.1",
+				"yaml": "^2.8.3"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-dictionary": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.0.tgz",
+			"integrity": "sha512-KubSoEAJO+77KPSSWjoLCz0+MIWVNq3joGTSyxucAZrBSJD64Y1O4BHHr1aj6XHIZwXhWWNScQlrQR3OcIulng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-performance-monitor": "10.0.0",
+				"@cspell/cspell-pipe": "10.0.0",
+				"@cspell/cspell-types": "10.0.0",
+				"cspell-trie-lib": "10.0.0",
+				"fast-equals": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-gitignore": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.0.tgz",
+			"integrity": "sha512-55XLH9Y52eR7QgyV28Uaw8V9cN1YZ3PQIyrN9YBR4ndQNBKJxO9+jX1nwSspwnccCZiE/N+GGxFzRBb75JDSCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/url": "10.0.0",
+				"cspell-glob": "10.0.0",
+				"cspell-io": "10.0.0"
+			},
+			"bin": {
+				"cspell-gitignore": "bin.mjs"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-glob": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.0.tgz",
+			"integrity": "sha512-bXS35fMcA9X7GEkfnWBfoPd/vTnxxfXW+YHt6tWxu5fejfs00qUbjWp1oLC9FxRaXWxIkfsYp2mi1k1jYl4RVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/url": "10.0.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-glob/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/cspell-grammar": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.0.tgz",
+			"integrity": "sha512-49udtYzkcCYEIDJbFOb4IwiAJebOYZnYvG6o6Ep19Tq0Xwjk7i4vxUprNiFNDCWFbcbJRPE9cpwQUVwp5WFGLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-pipe": "10.0.0",
+				"@cspell/cspell-types": "10.0.0"
+			},
+			"bin": {
+				"cspell-grammar": "bin.mjs"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-io": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.0.tgz",
+			"integrity": "sha512-NQCAUhx9DwKApxPuFl7EK1K1XSaQEAPld45yjjwv93xF8rJkEGkgzOwjbqafwAD20eKYv1a7oj/9EC0S5jETSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-service-bus": "10.0.0",
+				"@cspell/url": "10.0.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-lib": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.0.tgz",
+			"integrity": "sha512-PowW6JEjuv/F2aFEirZvBxpzHdchOnpsUJbeIcFcai0++taLTbHQObROBEBf7e0S8DnHpVD5TZkqrTME5e44wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspell/cspell-bundled-dicts": "10.0.0",
+				"@cspell/cspell-performance-monitor": "10.0.0",
+				"@cspell/cspell-pipe": "10.0.0",
+				"@cspell/cspell-resolver": "10.0.0",
+				"@cspell/cspell-types": "10.0.0",
+				"@cspell/dynamic-import": "10.0.0",
+				"@cspell/filetypes": "10.0.0",
+				"@cspell/rpc": "10.0.0",
+				"@cspell/strong-weak-map": "10.0.0",
+				"@cspell/url": "10.0.0",
+				"cspell-config-lib": "10.0.0",
+				"cspell-dictionary": "10.0.0",
+				"cspell-glob": "10.0.0",
+				"cspell-grammar": "10.0.0",
+				"cspell-io": "10.0.0",
+				"cspell-trie-lib": "10.0.0",
+				"env-paths": "^4.0.0",
+				"gensequence": "^8.0.8",
+				"import-fresh": "^4.0.0",
+				"resolve-from": "^5.0.0",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"vscode-uri": "^3.1.0",
+				"xdg-basedir": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=22.18.0"
+			}
+		},
+		"node_modules/cspell-lib/node_modules/import-fresh": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
+			"integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.15"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cspell-lib/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cspell-trie-lib": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.0.tgz",
+			"integrity": "sha512-R8qrMx10E/bm3Lecslwxn9XYo5NzSRK1rtandEX5n9UmEYHoBXjZELkg5+TOnV8VgrVaJSK57XtcGrbKp/4kSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.18.0"
+			},
+			"peerDependencies": {
+				"@cspell/cspell-types": "10.0.0"
+			}
+		},
+		"node_modules/cspell/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cspell/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/cssesc": {
@@ -2933,6 +3869,22 @@
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/env-paths": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+			"integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-safe-filename": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/es-abstract": {
 			"version": "1.24.1",
@@ -3591,6 +4543,20 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/esquery": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3666,6 +4632,16 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/fast-equals": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+			"integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -3789,9 +4765,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3964,6 +4940,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/gensequence": {
+			"version": "8.0.8",
+			"resolved": "https://registry.npmjs.org/gensequence/-/gensequence-8.0.8.tgz",
+			"integrity": "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4090,6 +5076,22 @@
 			"dependencies": {
 				"min-document": "^2.19.0",
 				"process": "^0.11.10"
+			}
+		},
+		"node_modules/global-directory": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+			"integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ini": "6.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globals": {
@@ -4327,6 +5329,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4335,6 +5348,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/ini": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+			"integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/internal-slot": {
@@ -4656,6 +5679,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-safe-filename": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+			"integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-set": {
@@ -6657,6 +7693,19 @@
 				"node": ">=0.12.18"
 			}
 		},
+		"node_modules/smol-toml": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7440,6 +8489,20 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7555,6 +8618,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/xdg-basedir": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+			"integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/xhr": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
@@ -7615,6 +8691,22 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@types/react": "^19.0.0",
 				"@types/react-dom": "^19.0.0",
 				"autoprefixer": "^10.4.24",
-				"cspell": "^10.0.0",
+				"cspell": "^9.8.0",
 				"eslint": "^9",
 				"eslint-config-next": "^16.1.6",
 				"postcss": "^8",
@@ -317,9 +317,9 @@
 			}
 		},
 		"node_modules/@cspell/cspell-bundled-dicts": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.0.tgz",
-			"integrity": "sha512-ci410HEkng2582oOjlRHQtlGXwh+rUC/mVcN9dObLHpKhvPgzn2S6vT56pARstxxZpcCUG/oLhn3dCqdJlVzmA==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.8.0.tgz",
+			"integrity": "sha512-MpXFpVyBPfJQ1YuVotljqUaGf6lWuf+fuWBBgs0PHFYTSjRPWuIxviAaCDnup/CJLLH60xQL4IlcQe4TOjzljw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -384,86 +384,86 @@
 				"@cspell/dict-zig": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/cspell-json-reporter": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.0.tgz",
-			"integrity": "sha512-hq5dui2ngYMZKbBauX7K1tkqlu81sX/uaCO49ZJLPjeZsE1auZLtHehDLfAr/ZXoj/dLYeQMSKiaJyE+qLVPHA==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.8.0.tgz",
+			"integrity": "sha512-nqUaSo9T7l8KrE22gc7ZIs+zvP7ak1i7JqGdRs8sGvh2Ijqj43qYQLePgb1b/vm8a1bavnc51m+vf05hpd3g3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-types": "10.0.0"
+				"@cspell/cspell-types": "9.8.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/cspell-performance-monitor": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.0.tgz",
-			"integrity": "sha512-2vMh2pLt2dg/ArYvWjMP4v9HCm0pRhONsEJyc8oHdZyOYvX7trixX894I0M39+VBf3yWtPCEgYRh1UDXNIZRig==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.8.0.tgz",
+			"integrity": "sha512-IsrXYzn23yJICIQ915ACdf+2lNEcFNTu5BIQt3khHOsGVvZ9/AZYpu9Dk825vUyZG7RHg2Oi6dYNiJtULG4ouQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20.18"
 			}
 		},
 		"node_modules/@cspell/cspell-pipe": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.0.tgz",
-			"integrity": "sha512-qcgHhQvtEX8LSwIVsWrdUgiGim52lN3jT+ghlkdp72v+nBcGKsS2frEKTmbGLug+xcqppkzs6Q6VmsFp1MGtfA==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.8.0.tgz",
+			"integrity": "sha512-ISEUD8PHYkd2Ktafc6hFfIXdGKYUvthA09NbwwZsWmOqYyk4wWKHZKqyyxD+BcrFwOyMOJcD8OEvIjkRQp2SJw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/cspell-resolver": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.0.tgz",
-			"integrity": "sha512-8H+IUDB7SmrpcRugQ5f55qG81ZShk6nQRk+natLz41TEY98D8/LCmjHEkh/vhDPph9pVJmNUp7JcM2E1UHEa2g==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.8.0.tgz",
+			"integrity": "sha512-PZJj56BZpKfMxOzWkyt7b+aIXObe+8Ku/zLI4xDXPSuQPENbHBFHfPIZx68CyGEkanKxZ1ewKVx/FT1FUy+wDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-directory": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/cspell-service-bus": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.0.tgz",
-			"integrity": "sha512-V7eigqg/TOoKwNK4Q18wr9KGxA8U5SFcoWVS8RyAxv4mQ+yNKHhvHEbRBifjPbQDer66afOrclb2UbqkIy2SOw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.8.0.tgz",
+			"integrity": "sha512-P45sd2nqwcqhulBBbQnZB/JNcobecTrP4Ky3vmEq0cprsvavc+ZoHF9U2Ql5ghMSUzjrF2n1aNzZ8cH4IlsnKg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/cspell-types": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.0.tgz",
-			"integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.8.0.tgz",
+			"integrity": "sha512-7Ge4UD6SCA49Tcc3+GTlz3Xn4cqVUAXtDO0u9IeHvJgkN3Me2Rw2GB/CtGmhKST3YeEeZMX7ww09TdHMUJlehw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/cspell-worker": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.0.tgz",
-			"integrity": "sha512-V5bjMldNksilnja3fu8muQmkW5/guyua1yNVOhoE2r7othSvjuDlGMl8g2bQSrWjp+UXu0dP/BEZ6JC/IfNwTA==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.8.0.tgz",
+			"integrity": "sha512-W8FLdE3MXPLbWtAXciILQhk9CHd6Mt+HRjZHM8m+dwE1Bc2TAjUai8kIxsdhHUq58p7gYY2ekr5sg1uYOUgTAA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cspell-lib": "10.0.0"
+				"cspell-lib": "9.8.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20.18"
 			}
 		},
 		"node_modules/@cspell/dict-ada": {
@@ -892,57 +892,57 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dynamic-import": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.0.tgz",
-			"integrity": "sha512-fMqu/5Ma1Q5ZCR/Par+Q4pvaTKmx5pKZzQmkwld2hNounVdk2OaIPM9MzpNn6I1mLk5J+wTnIZmfcWNAzNP9aQ==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.8.0.tgz",
+			"integrity": "sha512-wMgb32lqG9g6lCipUQsY9Bk5idXPDz7wvzOqEsU1M2HmNYmdE1wfPoRpfQfsVL965iG3+6h8QLr2+8FKpweFEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/url": "10.0.0",
+				"@cspell/url": "9.8.0",
 				"import-meta-resolve": "^4.2.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/filetypes": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.0.tgz",
-			"integrity": "sha512-UP57j9yrDtlCHpFxc/eGho1m8DP5olfu9KRWwd5fiqL9nMSE2rUJtPzQyvqmDwO5bVZt3B+fTVdo4gxuiqw25A==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.8.0.tgz",
+			"integrity": "sha512-yHvtYn9qt6zykua77sNzTcf7HrG/dpo/+2pCMGSrfSrQypSNT6FUFvMS04W7kwhP86U1GkCjppNykXuoH3cqug==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/rpc": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.0.tgz",
-			"integrity": "sha512-QrpOZMwz2pAjvl6Hky2PauYoMpLCASn3osjn7uKUbgFV70sahyj6tmx4rRgRX7vHu2WQLZev+YsuO4EujiBDOg==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.8.0.tgz",
+			"integrity": "sha512-t4lHEa254W+PePXNQ1noW7QhQxz/mhsJ9X8LEt0ILzBbPWCJzN+JuaM7EiolIPiwxtfxpMwKx9482kt4eTja7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20.18"
 			}
 		},
 		"node_modules/@cspell/strong-weak-map": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.0.tgz",
-			"integrity": "sha512-JRsato0s2IjYdsng+AGL6oAqgZVQgih5aWKdmxs21H6EdhMaoFDmRE5kXm/RT5a6OMdtnzQM9DqeToqBChWIOQ==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.8.0.tgz",
+			"integrity": "sha512-HocksAqZ0JcWA5oWO7TIlOCftXVGkPGzbeFlCRRrjJpZmYQH+4NdeEXyQC6T89NGocp45td/CgyBcAaFMy1N9w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@cspell/url": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.0.tgz",
-			"integrity": "sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.8.0.tgz",
+			"integrity": "sha512-LY1lFiZLTQF/ma1ilfKmRmFmEOw0RfYhyl0UMhY7/d93b+kiDMhxP/9Qir4+5LyiRncaE3++ZcWno9Hya+ssRg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -3293,6 +3293,46 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/clear-module": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+			"integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parent-module": "^2.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clear-module/node_modules/parent-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+			"integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"callsites": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/clear-module/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3393,29 +3433,29 @@
 			}
 		},
 		"node_modules/cspell": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.0.tgz",
-			"integrity": "sha512-R25gsSR1SLlcGyw48fwJwp0PjXrVdl7RDO/Dm5+s4DvC1uQSlyiUxsr/8ZtbyC/MPeUJFQN9B4luqLlSm0WelQ==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell/-/cspell-9.8.0.tgz",
+			"integrity": "sha512-qL0VErMSn8BDxaPxcV+9uenffgjPS+5Jfz+m4rCsvYjzLwr7AaaJBWWSV2UiAe/4cturae8n8qzxiGnbbazkRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-json-reporter": "10.0.0",
-				"@cspell/cspell-performance-monitor": "10.0.0",
-				"@cspell/cspell-pipe": "10.0.0",
-				"@cspell/cspell-types": "10.0.0",
-				"@cspell/cspell-worker": "10.0.0",
-				"@cspell/dynamic-import": "10.0.0",
-				"@cspell/url": "10.0.0",
+				"@cspell/cspell-json-reporter": "9.8.0",
+				"@cspell/cspell-performance-monitor": "9.8.0",
+				"@cspell/cspell-pipe": "9.8.0",
+				"@cspell/cspell-types": "9.8.0",
+				"@cspell/cspell-worker": "9.8.0",
+				"@cspell/dynamic-import": "9.8.0",
+				"@cspell/url": "9.8.0",
 				"ansi-regex": "^6.2.2",
 				"chalk": "^5.6.2",
 				"chalk-template": "^1.1.2",
 				"commander": "^14.0.3",
-				"cspell-config-lib": "10.0.0",
-				"cspell-dictionary": "10.0.0",
-				"cspell-gitignore": "10.0.0",
-				"cspell-glob": "10.0.0",
-				"cspell-io": "10.0.0",
-				"cspell-lib": "10.0.0",
+				"cspell-config-lib": "9.8.0",
+				"cspell-dictionary": "9.8.0",
+				"cspell-gitignore": "9.8.0",
+				"cspell-glob": "9.8.0",
+				"cspell-io": "9.8.0",
+				"cspell-lib": "9.8.0",
 				"fast-json-stable-stringify": "^2.1.0",
 				"flatted": "^3.4.2",
 				"semver": "^7.7.4",
@@ -3426,75 +3466,75 @@
 				"cspell-esm": "bin.mjs"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20.18"
 			},
 			"funding": {
 				"url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
 			}
 		},
 		"node_modules/cspell-config-lib": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.0.tgz",
-			"integrity": "sha512-HWK7SRnJ3N/kOThw/uzmXmQYCzBxu58Jkq2hHyte1voDl118BeNFoaNRWMpYdHbBi3kCj8gaZu8wGtm+Zmdhxw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.8.0.tgz",
+			"integrity": "sha512-gMJBAgYPvvO+uDFLUcGWaTu6/e+r8mm4GD4rQfWa/yV4F9fj+yOYLIMZqLWRvT1moHZX1FxyVvUbJcmZ1gfebg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-types": "10.0.0",
+				"@cspell/cspell-types": "9.8.0",
 				"comment-json": "^4.6.2",
 				"smol-toml": "^1.6.1",
 				"yaml": "^2.8.3"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-dictionary": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.0.tgz",
-			"integrity": "sha512-KubSoEAJO+77KPSSWjoLCz0+MIWVNq3joGTSyxucAZrBSJD64Y1O4BHHr1aj6XHIZwXhWWNScQlrQR3OcIulng==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.8.0.tgz",
+			"integrity": "sha512-QW4hdkWcrxZA1QNqi26U0S/U3/V+tKCm7JaaesEJW2F6Ao+23AbHVwidyAVtXaEhGkn6PxB+epKrrAa6nE69qA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-performance-monitor": "10.0.0",
-				"@cspell/cspell-pipe": "10.0.0",
-				"@cspell/cspell-types": "10.0.0",
-				"cspell-trie-lib": "10.0.0",
+				"@cspell/cspell-performance-monitor": "9.8.0",
+				"@cspell/cspell-pipe": "9.8.0",
+				"@cspell/cspell-types": "9.8.0",
+				"cspell-trie-lib": "9.8.0",
 				"fast-equals": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-gitignore": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.0.tgz",
-			"integrity": "sha512-55XLH9Y52eR7QgyV28Uaw8V9cN1YZ3PQIyrN9YBR4ndQNBKJxO9+jX1nwSspwnccCZiE/N+GGxFzRBb75JDSCw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.8.0.tgz",
+			"integrity": "sha512-SDUa1DmSfT20+JH7XtyzcEL9KfurneoR/XbmlrtPQZP/LUHXh3yz4x/0vFIkEFXNWdSckY0QdWTz8DaxClCf4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/url": "10.0.0",
-				"cspell-glob": "10.0.0",
-				"cspell-io": "10.0.0"
+				"@cspell/url": "9.8.0",
+				"cspell-glob": "9.8.0",
+				"cspell-io": "9.8.0"
 			},
 			"bin": {
 				"cspell-gitignore": "bin.mjs"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-glob": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.0.tgz",
-			"integrity": "sha512-bXS35fMcA9X7GEkfnWBfoPd/vTnxxfXW+YHt6tWxu5fejfs00qUbjWp1oLC9FxRaXWxIkfsYp2mi1k1jYl4RVw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.8.0.tgz",
+			"integrity": "sha512-Uvj/iHXs+jpsJyIEnhEoJTWXb1GVyZ9T05L5JFtZfsQNXrh8SRDQPscjxbg4okKr63N7WevfioQum/snHNYvmw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/url": "10.0.0",
+				"@cspell/url": "9.8.0",
 				"picomatch": "^4.0.4"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-glob/node_modules/picomatch": {
@@ -3511,82 +3551,70 @@
 			}
 		},
 		"node_modules/cspell-grammar": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.0.tgz",
-			"integrity": "sha512-49udtYzkcCYEIDJbFOb4IwiAJebOYZnYvG6o6Ep19Tq0Xwjk7i4vxUprNiFNDCWFbcbJRPE9cpwQUVwp5WFGLw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.8.0.tgz",
+			"integrity": "sha512-01XMq2vhPS0Gvxnfed9uvOwH+3cXddHYxW0PwCE+SZdcC6TN8yM6glByuLt1qFustAmQVE5GSr7uAY9o4pZQRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-pipe": "10.0.0",
-				"@cspell/cspell-types": "10.0.0"
+				"@cspell/cspell-pipe": "9.8.0",
+				"@cspell/cspell-types": "9.8.0"
 			},
 			"bin": {
 				"cspell-grammar": "bin.mjs"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-io": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.0.tgz",
-			"integrity": "sha512-NQCAUhx9DwKApxPuFl7EK1K1XSaQEAPld45yjjwv93xF8rJkEGkgzOwjbqafwAD20eKYv1a7oj/9EC0S5jETSw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.8.0.tgz",
+			"integrity": "sha512-JINaEWQEzR4f2upwdZOFcft+nBvQgizJfrOLszxG3p+BIzljnGklqE/nUtLFZpBu0oMJvuM/Fd+GsWor0yP7Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-service-bus": "10.0.0",
-				"@cspell/url": "10.0.0"
+				"@cspell/cspell-service-bus": "9.8.0",
+				"@cspell/url": "9.8.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-lib": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.0.tgz",
-			"integrity": "sha512-PowW6JEjuv/F2aFEirZvBxpzHdchOnpsUJbeIcFcai0++taLTbHQObROBEBf7e0S8DnHpVD5TZkqrTME5e44wg==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.8.0.tgz",
+			"integrity": "sha512-G2TtPcye5QE5ev3YgWq42UOJLpTZ6naO/47oIm+jmeSYbgnbcOSThnEE7uMycx+TTNOz/vJVFpZmQyt0bWCftw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/cspell-bundled-dicts": "10.0.0",
-				"@cspell/cspell-performance-monitor": "10.0.0",
-				"@cspell/cspell-pipe": "10.0.0",
-				"@cspell/cspell-resolver": "10.0.0",
-				"@cspell/cspell-types": "10.0.0",
-				"@cspell/dynamic-import": "10.0.0",
-				"@cspell/filetypes": "10.0.0",
-				"@cspell/rpc": "10.0.0",
-				"@cspell/strong-weak-map": "10.0.0",
-				"@cspell/url": "10.0.0",
-				"cspell-config-lib": "10.0.0",
-				"cspell-dictionary": "10.0.0",
-				"cspell-glob": "10.0.0",
-				"cspell-grammar": "10.0.0",
-				"cspell-io": "10.0.0",
-				"cspell-trie-lib": "10.0.0",
+				"@cspell/cspell-bundled-dicts": "9.8.0",
+				"@cspell/cspell-performance-monitor": "9.8.0",
+				"@cspell/cspell-pipe": "9.8.0",
+				"@cspell/cspell-resolver": "9.8.0",
+				"@cspell/cspell-types": "9.8.0",
+				"@cspell/dynamic-import": "9.8.0",
+				"@cspell/filetypes": "9.8.0",
+				"@cspell/rpc": "9.8.0",
+				"@cspell/strong-weak-map": "9.8.0",
+				"@cspell/url": "9.8.0",
+				"clear-module": "^4.1.2",
+				"cspell-config-lib": "9.8.0",
+				"cspell-dictionary": "9.8.0",
+				"cspell-glob": "9.8.0",
+				"cspell-grammar": "9.8.0",
+				"cspell-io": "9.8.0",
+				"cspell-trie-lib": "9.8.0",
 				"env-paths": "^4.0.0",
 				"gensequence": "^8.0.8",
-				"import-fresh": "^4.0.0",
+				"import-fresh": "^3.3.1",
 				"resolve-from": "^5.0.0",
 				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-uri": "^3.1.0",
 				"xdg-basedir": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=22.18.0"
-			}
-		},
-		"node_modules/cspell-lib/node_modules/import-fresh": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
-			"integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=22.15"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=20"
 			}
 		},
 		"node_modules/cspell-lib/node_modules/resolve-from": {
@@ -3600,16 +3628,16 @@
 			}
 		},
 		"node_modules/cspell-trie-lib": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.0.tgz",
-			"integrity": "sha512-R8qrMx10E/bm3Lecslwxn9XYo5NzSRK1rtandEX5n9UmEYHoBXjZELkg5+TOnV8VgrVaJSK57XtcGrbKp/4kSg==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.8.0.tgz",
+			"integrity": "sha512-GXIyqxya8QLp6SjKsAN9w3apvt1Ww7GKcZvTBaP76OfLoyb1QC6unwmObY2cZs1manCntGwHrgU6vFNuXnTzpw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=22.18.0"
+				"node": ">=20"
 			},
 			"peerDependencies": {
-				"@cspell/cspell-types": "10.0.0"
+				"@cspell/cspell-types": "9.8.0"
 			}
 		},
 		"node_modules/cspell/node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
 		"build": "next build",
 		"start": "next start",
 		"lint": "eslint .",
+		"typecheck": "tsc --noEmit",
+		"spell": "cspell --no-progress 'src/**/*.{ts,tsx}' '*.md'",
 		"favicon": "node tools/generate-favicon.mjs",
 		"logos": "node tools/fetch-official-logos.mjs"
 	},
@@ -23,6 +25,7 @@
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"autoprefixer": "^10.4.24",
+		"cspell": "^10.0.0",
 		"eslint": "^9",
 		"eslint-config-next": "^16.1.6",
 		"postcss": "^8",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"autoprefixer": "^10.4.24",
-		"cspell": "^10.0.0",
+		"cspell": "^9.8.0",
 		"eslint": "^9",
 		"eslint-config-next": "^16.1.6",
 		"postcss": "^8",


### PR DESCRIPTION
## Summary
Until now, \`deploy.yml\` only ran lint/typecheck/build on push to \`main\` — PRs could be merged without ever validating the build. This adds a \`ci.yml\` workflow that runs on every PR (and every non-main push) with three parallel jobs:

### \`lint-and-typecheck\`
- ESLint
- \`tsc --noEmit\`
- \`next build\`

Catches type errors, lint errors, and build-time failures before merge.

### \`spell-check\`
- \`cspell\` across \`src/**/*.{ts,tsx}\` and \`*.md\` files

Past audit passes caught real typos that would have been prevented here:
- \"Czestochowa\" → \"Częstochowa\" (5 files)
- \"diploma-suplement.pdf\" → \"diploma-supplement.pdf\"

Custom dictionary in \`cspell.json\` lists project nouns (Andrii, Lytvynenko, Geniusee, Luxoft, MBUX, Częstochowa, etc.).

### \`link-check\`
- \`lychee\` scans every URL in source / markdown / sitemap

Past audits caught four 404'd GitHub repos this way; now CI catches them automatically. \`lychee.toml\` excludes bot-hostile sites (LinkedIn, WhatsApp, Telegram) that probe-block any non-browser request, and accepts 403/999 status codes for similar reasons.

## Other changes
- Added \`typecheck\` and \`spell\` npm scripts so CI and local dev share the same commands.
- \`deploy.yml\` now uses \`node-version-file: .nvmrc\` instead of pinning \"20\" twice, and uses \`npm run typecheck\` instead of inline npx.
- Concurrency cancellation on CI (cancel stale runs on new pushes), but **not** on deploy — let in-flight production deploys finish.

## Test plan
- [x] \`npm run lint\` → 0 errors locally
- [x] \`npm run typecheck\` → clean
- [x] \`npm run spell\` → 40 files, 0 issues
- [x] \`npm run build\` → all 9 routes generate
- [x] \`lychee --config ./lychee.toml ...\` → 49 URLs scanned, 0 errors
- [ ] CI green on this PR (will know once GitHub Actions runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)