### PR TITLE
fix: align privacy & cookie policies with consent-first model

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -18,6 +18,7 @@ max_redirects = 5
 # Skip these — either site-internal patterns or known-good but bot-blocked.
 # LinkedIn returns 404/405/999 to non-browser clients, so exclude entirely.
 # Telegram and WhatsApp short links don't respond well to HEAD/GET probes.
+# uodo.gov.pl (Polish DPA) uses a national-CA cert lychee's truststore rejects.
 exclude = [
     "^https?://localhost",
     "^https?://127\\.0\\.0\\.1",
@@ -25,6 +26,7 @@ exclude = [
     "^https://wa\\.me/",
     "^https://t\\.me/",
     "^https://api\\.whatsapp\\.com/",
+    "^https://(www\\.)?uodo\\.gov\\.pl/",
 ]
 
 # What to scan: source files + content files. Skip build output.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -14,13 +14,13 @@
   </url>
   <url>
     <loc>https://alytvynenko.net/privacy-policy/</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://alytvynenko.net/cookie-policy/</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -9,12 +9,12 @@ const PROFILE_IMAGE = `${SITE_URL}/images/tm-easy-profile.webp`;
 export const metadata: Metadata = {
 	title: "Cookie Policy - Andrii Lytvynenko",
 	description:
-		"Cookie Policy for alytvynenko.net. Learn about the cookies we use, including Google Analytics, and how to manage your preferences.",
+		"Cookie Policy for alytvynenko.net. Learn about the cookies I use, including Google Analytics, and how to manage your preferences.",
 	robots: { index: false, follow: true },
 	openGraph: {
 		title: "Cookie Policy - Andrii Lytvynenko",
 		description:
-			"Cookie Policy for alytvynenko.net. Learn about the cookies we use, including Google Analytics, and how to manage your preferences.",
+			"Cookie Policy for alytvynenko.net. Learn about the cookies I use, including Google Analytics, and how to manage your preferences.",
 		url: `${SITE_URL}/cookie-policy/`,
 		images: [{ url: PROFILE_IMAGE, width: 250, height: 250, alt: "Andrii Lytvynenko" }],
 		type: "website",
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 		card: "summary_large_image",
 		title: "Cookie Policy - Andrii Lytvynenko",
 		description:
-			"Cookie Policy for alytvynenko.net. Learn about the cookies we use, including Google Analytics, and how to manage your preferences.",
+			"Cookie Policy for alytvynenko.net. Learn about the cookies I use, including Google Analytics, and how to manage your preferences.",
 		images: [PROFILE_IMAGE],
 	},
 };
@@ -58,17 +58,17 @@ export default function CookiePolicyPage() {
 						<h1 className="mb-2 text-4xl font-bold tracking-tight text-foreground">
 							Cookie Policy
 						</h1>
-						<p className="mb-8 text-muted">Last updated: February 16, 2026</p>
+						<p className="mb-8 text-muted">Last updated: May 15, 2026</p>
 
 						<div className="prose prose-lg dark:prose-invert max-w-none">
 							<p>
-								This Cookie Policy explains how <strong>alytvynenko.net</strong> (the
+								This Cookie Policy explains how <strong>alytvynenko.net</strong>{" "}(the
 								&quot;Website&quot;) uses cookies and similar technologies. It
-								complements our{" "}
+								complements my{" "}
 								<Link href="/privacy-policy" className="text-accent hover:underline">
 									Privacy Policy
 								</Link>
-								, which provides broader information about how we collect and use
+								, which provides broader information about how I collect and use
 								your data.
 							</p>
 
@@ -97,27 +97,29 @@ export default function CookiePolicyPage() {
 							<p>
 								Cookies are small text files stored on your device when you visit
 								a website. They help websites remember your preferences, improve
-								performance, and provide analytics. This Website uses cookies only
-								after you have given your consent via our cookie banner.
+								performance, and provide analytics. This Website uses analytics
+								cookies only after you have given your consent via the cookie
+								banner.
 							</p>
 
 							<h2 className="mt-10 border-b border-border pb-2 text-2xl font-bold text-foreground">
-								3. Cookies We Use
+								3. Cookies I Use
 							</h2>
 
 							<h3 className="mt-6 text-xl font-semibold text-foreground">
-								3.1 Essential Cookies
+								3.1 Essential Site Storage
 							</h3>
 							<p>
-								These cookies are necessary for the Website to function. They
-								include:
+								The following items are necessary for the Website to function.
+								They are stored as browser localStorage entries (not HTTP
+								cookies), but serve similar purposes:
 							</p>
 							<div className="my-6 overflow-x-auto">
 								<table className="w-full border-collapse border border-border">
 									<thead>
 										<tr>
 											<th className="border border-border bg-accent/30 px-4 py-3 text-left font-semibold text-foreground">
-												Cookie Name
+												Name
 											</th>
 											<th className="border border-border bg-accent/30 px-4 py-3 text-left font-semibold text-foreground">
 												Purpose
@@ -133,10 +135,10 @@ export default function CookiePolicyPage() {
 												<code className="text-foreground">theme</code>
 											</td>
 											<td className="border border-border px-4 py-3 text-muted">
-												Technical session management: Stores your light/dark theme preference (localStorage)
+												Stores your light/dark theme preference
 											</td>
 											<td className="border border-border px-4 py-3 text-muted">
-												Persistent
+												Persistent (until cleared)
 											</td>
 										</tr>
 										<tr>
@@ -144,10 +146,10 @@ export default function CookiePolicyPage() {
 												<code className="text-foreground">cookie-consent</code>
 											</td>
 											<td className="border border-border bg-surface px-4 py-3 text-muted">
-												Technical session management: Stores your cookie consent choice (localStorage)
+												Stores your cookie consent choice
 											</td>
 											<td className="border border-border bg-surface px-4 py-3 text-muted">
-												Persistent (1 year)
+												Persistent (until cleared)
 											</td>
 										</tr>
 									</tbody>
@@ -158,8 +160,8 @@ export default function CookiePolicyPage() {
 								3.2 Analytics Cookies (Google Analytics 4)
 							</h3>
 							<p>
-								When you accept analytics cookies, we use Google Analytics 4 (GA4)
-								to understand how visitors use our Website. GA4 sets the
+								When you accept analytics cookies, I use Google Analytics 4 (GA4)
+								to understand how visitors use the Website. GA4 sets the
 								following first-party cookies:
 							</p>
 							<div className="my-6 overflow-x-auto">

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -9,12 +9,12 @@ const PROFILE_IMAGE = `${SITE_URL}/images/tm-easy-profile.webp`;
 export const metadata: Metadata = {
 	title: "Privacy Policy - Andrii Lytvynenko",
 	description:
-		"Privacy Policy for Andrii Lytvynenko's personal website. Learn how we handle your data, cookies, and your rights under GDPR.",
+		"Privacy Policy for Andrii Lytvynenko's personal website. Learn how I handle your data, cookies, and your rights under GDPR.",
 	robots: { index: false, follow: true },
 	openGraph: {
 		title: "Privacy Policy - Andrii Lytvynenko",
 		description:
-			"Privacy Policy for Andrii Lytvynenko's personal website. Learn how we handle your data, cookies, and your rights under GDPR.",
+			"Privacy Policy for Andrii Lytvynenko's personal website. Learn how I handle your data, cookies, and your rights under GDPR.",
 		url: `${SITE_URL}/privacy-policy/`,
 		images: [{ url: PROFILE_IMAGE, width: 250, height: 250, alt: "Andrii Lytvynenko" }],
 		type: "website",
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 		card: "summary_large_image",
 		title: "Privacy Policy - Andrii Lytvynenko",
 		description:
-			"Privacy Policy for Andrii Lytvynenko's personal website. Learn how we handle your data, cookies, and your rights under GDPR.",
+			"Privacy Policy for Andrii Lytvynenko's personal website. Learn how I handle your data, cookies, and your rights under GDPR.",
 		images: [PROFILE_IMAGE],
 	},
 };
@@ -58,11 +58,11 @@ export default function PrivacyPolicyPage() {
 						<h1 className="mb-2 text-4xl font-bold tracking-tight text-foreground">
 							Privacy Policy
 						</h1>
-						<p className="mb-8 text-muted">Last updated: January 19, 2026</p>
+						<p className="mb-8 text-muted">Last updated: May 15, 2026</p>
 
 						<div className="prose prose-lg dark:prose-invert max-w-none">
 							<p>
-								Welcome to <strong>alytvynenko.net</strong> (the &quot;Website&quot;),
+								Welcome to <strong>alytvynenko.net</strong>{" "}(the &quot;Website&quot;),
 								operated by Andrii Lytvynenko (&quot;I&quot;, &quot;me&quot;, or
 								&quot;my&quot;). I am committed to protecting your privacy and
 								handling your personal data in compliance with the General Data
@@ -102,8 +102,23 @@ export default function PrivacyPolicyPage() {
 								2.1 Information Collected Automatically
 							</h3>
 							<p>
-								When you visit my Website, certain information is collected
-								automatically through cookies and similar technologies:
+								The information collected automatically depends on whether you
+								accept analytics cookies via the consent banner.
+							</p>
+							<p className="mt-4">
+								<strong className="text-foreground">
+									Always (regardless of consent):
+								</strong>
+							</p>
+							<ul className="list-disc space-y-2 pl-6 text-muted">
+								<li>
+									<strong className="text-foreground">Server Logs:</strong> Standard server logs (including public IP addresses, browser information, time of request, and HTTP response codes) are processed by GitHub, the hosting provider, for the security and technical functioning of the Website. I do not have direct access to these logs.
+								</li>
+							</ul>
+							<p className="mt-4">
+								<strong className="text-foreground">
+									Only after you accept analytics cookies (via Google Analytics 4):
+								</strong>
 							</p>
 							<ul className="list-disc space-y-2 pl-6 text-muted">
 								<li>
@@ -115,15 +130,14 @@ export default function PrivacyPolicyPage() {
 									visited, time spent on pages, click patterns, scroll depth
 								</li>
 								<li>
-									<strong className="text-foreground">Technical Data:</strong> IP
-									address (anonymized), referring URL, date and time of visit
-								</li>
-								<li>
-									<strong className="text-foreground">Server Logs:</strong> Standard website server logs, including public IP addresses, browser information, time of request, and HTTP response codes. This technical data is collected specifically for the security and technical functioning of the website.
+									<strong className="text-foreground">Technical Data:</strong>{" "}
+									Referring URL, date and time of visit (GA4 does not store full
+									IP addresses)
 								</li>
 								<li>
 									<strong className="text-foreground">Location Data:</strong> General
-									geographic location (country/region level only)
+									geographic location (country/region level only), derived from IP
+									by Google
 								</li>
 							</ul>
 
@@ -144,13 +158,15 @@ export default function PrivacyPolicyPage() {
 								3. Analytics Services
 							</h2>
 							<p>
-								I use the following third-party analytics services to understand
-								how visitors interact with my Website:
+								I use Google Analytics 4 to understand how visitors interact with
+								my Website. Analytics scripts are only loaded after you accept
+								analytics cookies via the consent banner. If you reject, no
+								analytics scripts are loaded and no analytics cookies are set.
 							</p>
 							<p>
-								This Website uses Google Analytics 4, a web analytics service
-								provided by Google LLC. Google Analytics uses cookies to analyze
-								your use of the Website.
+								When enabled, Google Analytics 4 (a web analytics service
+								provided by Google LLC) uses cookies to analyze your use of the
+								Website.
 							</p>
 							<div className="my-6 rounded-xl border-l-4 border-accent bg-surface p-4">
 								<strong className="text-foreground">Data Collected:</strong> Page
@@ -191,7 +207,7 @@ export default function PrivacyPolicyPage() {
 							<p>
 								Cookies are small text files stored on your device when you visit
 								a website. This Website uses the following types of cookies. For
-								a detailed list of cookies, including Google Analytics, see our{" "}
+								a detailed list of cookies, including Google Analytics, see the{" "}
 								<Link href="/cookie-policy" className="text-accent hover:underline">
 									Cookie Policy
 								</Link>
@@ -218,11 +234,12 @@ export default function PrivacyPolicyPage() {
 												<strong className="text-foreground">Essential</strong>
 											</td>
 											<td className="border border-border px-4 py-3 text-muted">
-												Required for the Website to function properly (e.g.,
-												service worker)
+												Required for site preferences and consent management
+												(stored as browser localStorage; see the Cookie Policy
+												for details)
 											</td>
 											<td className="border border-border px-4 py-3 text-muted">
-												Session
+												Persistent
 											</td>
 										</tr>
 										<tr>
@@ -266,21 +283,24 @@ export default function PrivacyPolicyPage() {
 							</p>
 							<ul className="list-disc space-y-2 pl-6 text-muted">
 								<li>
+									<strong className="text-foreground">Consent (Art. 6(1)(a)
+									GDPR):</strong> For loading Google Analytics and the resulting
+									analytics cookies. No analytics processing occurs until you opt
+									in via the cookie banner, and you can withdraw consent at any
+									time.
+								</li>
+								<li>
 									<strong className="text-foreground">Contract Performance (Art.
 									6(1)(b) GDPR):</strong> When you contact me regarding potential
 									B2B collaboration or services, processing is necessary for taking steps prior to entering a contract.
 								</li>
 								<li>
 									<strong className="text-foreground">Legitimate Interest (Art.
-									6(1)(f) GDPR):</strong> For analytics purposes to improve the
-									Website and understand visitor behavior, and for processing B2B inquiries as part of my legitimate business interests. I have conducted a
-									balancing test to ensure my interests do not override your
-									rights.
-								</li>
-								<li>
-									<strong className="text-foreground">Consent (Art. 6(1)(a)
-									GDPR):</strong> Where explicitly obtained for specific
-									processing activities.
+									6(1)(f) GDPR):</strong> For the security and technical
+									functioning of the Website (e.g., server logs processed by
+									GitHub as the hosting provider) and for handling general
+									inquiries from B2B contacts. I have conducted a balancing test
+									to ensure my interests do not override your rights.
 								</li>
 							</ul>
 
@@ -313,7 +333,16 @@ export default function PrivacyPolicyPage() {
 								</li>
 								<li>
 									<strong className="text-foreground">Hosting Provider:</strong>{" "}
-									GitHub Pages, which hosts this Website
+									GitHub, Inc. (GitHub Pages), which hosts this Website. See the{" "}
+									<a
+										href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-accent hover:underline"
+									>
+										GitHub Privacy Statement
+									</a>{" "}
+									for details.
 								</li>
 								<li>
 									<strong className="text-foreground">Legal Authorities:</strong> If
@@ -356,8 +385,8 @@ export default function PrivacyPolicyPage() {
 									law. For B2B inquiries where a professional contract is not ultimately signed, communications are retained for 12 months after the last communication.
 								</li>
 								<li>
-									<strong className="text-foreground">Server Logs:</strong> Typically
-									90 days, retained specifically for the security and technical functioning of the website
+									<strong className="text-foreground">Server Logs:</strong> Retained
+									by GitHub as the hosting provider, according to its own retention practices, for the security and technical functioning of the Website
 								</li>
 							</ul>
 

--- a/src/components/ui/CookieConsentBanner.tsx
+++ b/src/components/ui/CookieConsentBanner.tsx
@@ -41,7 +41,7 @@ export function CookieConsentBanner({
 		>
 			<div className="mx-auto max-w-6xl sm:mx-0">
 				<p id="cookie-consent-description" className="mb-4 text-sm text-foreground">
-					We use cookies to analyze site traffic via Google Analytics. You can
+					I use cookies to analyze site traffic via Google Analytics. You can
 					accept or reject analytics cookies.{" "}
 					<Link
 						href="/cookie-policy"


### PR DESCRIPTION
## Summary

Reviewed the privacy and cookie policies against what the site actually does and reconciled the mismatches. The implementation gates Google Analytics behind the cookie banner ([ConsentProvider.tsx](src/components/providers/ConsentProvider.tsx)), but the policies described GA as if it ran unconditionally and cited Legitimate Interest as the legal basis for analytics — which is the kind of thing a DPA would flag.

### Privacy Policy
- **Legal basis (§5)** reordered: Consent is now correctly the basis for analytics; Legitimate Interest is scoped to security/server logs + B2B inquiries.
- **§3 Analytics** now states analytics scripts are only loaded after opt-in (matches the consent banner reality).
- **§2.1 "Information Collected Automatically"** restructured into two labeled groups: "Always (regardless of consent)" for GitHub-processed server logs, and "Only after you accept analytics cookies" for the GA-gated data points.
- **§4 cookies table**: the "Essential" row no longer falsely claims a service worker / Session — corrected to reflect the actual `theme` and `cookie-consent` localStorage entries (with a pointer to the Cookie Policy).
- **§2.1 + §9**: server logs correctly attributed to GitHub (the hosting provider). I don't have direct access to them.
- **§7 Data Sharing**: added a link to the GitHub Privacy Statement for the hosting provider.
- Outdated UA-era "IP address (anonymized)" language replaced — GA4 doesn't store full IPs.
- Voice unified to "I/my" throughout (metadata descriptions, "see our" → "see the").
- **JSX whitespace bug** fixed: `<strong>alytvynenko.net</strong> (the` was rendering as `alytvynenko.net(the` because JSX collapsed the trailing space — added explicit `{" "}`.
- "Last updated" → May 15, 2026.

### Cookie Policy
- Voice unified to "I/my" (intro, §2, §3.2, heading "Cookies I Use", metadata).
- **§3.1** renamed to "Essential Site Storage" with an intro clarifying these are localStorage entries, not HTTP cookies. Table header changed from "Cookie Name" to "Name".
- `cookie-consent` duration corrected from "Persistent (1 year)" to "Persistent (until cleared)" — there's no expiration logic in [ConsentProvider.tsx](src/components/providers/ConsentProvider.tsx).
- Same JSX whitespace bug fixed.
- "Last updated" → May 15, 2026.

### Cookie Consent Banner
- "We use cookies..." → "I use cookies..." to match the policies' voice.

### Sitemap
- `lastmod` for `/privacy-policy/` and `/cookie-policy/` bumped to 2026-05-15.

## Test plan

- [x] `npm run lint` — clean (only pre-existing image warnings)
- [x] `npm run typecheck` — clean
- [x] `npm run spell` — clean
- [x] `npm run build` — both policy pages prerender as static content
- [x] Live preview verified for both pages: new headings, restructured §2.1, voice changes, spacing fix all render correctly with no console or server errors
- [ ] `npm run e2e` — Playwright smoke covers nav/footer/h1 only, which are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)